### PR TITLE
Change the install script to be easier to run

### DIFF
--- a/opensearch-dashboard-prototyping/README.md
+++ b/opensearch-dashboard-prototyping/README.md
@@ -1,7 +1,9 @@
 
 # How to load dashboards into your Open Search installation
 
-Run the following shell script: `install_dashboards.sh`
+Run the following shell script: `./install_dashboards.sh http://localhost:9200 http://localhost:5601`
+
+To deploy in the Chorus for OpenSearch environment it would be: `./install_dashboards.sh http://chorus-opensearch-edition.dev.o19s.com:9200 http://chorus-opensearch-edition.dev.o19s.com:5601`
 
 # Prototype Dashboards in Notebook
 

--- a/opensearch-dashboard-prototyping/install_dashboards.sh
+++ b/opensearch-dashboard-prototyping/install_dashboards.sh
@@ -5,21 +5,28 @@ MAJOR='\033[0;34m'
 MINOR='\033[0;37m    '
 RESET='\033[0m' # No Color
 
-: ${OPEN_SEARCH:="localhost:9200"}
-: ${OPEN_SEARCH_DASHBOARDS:="localhost:5601"}
-
+opensearch=$1
+opensearch_dashboard=$2
 set -eo pipefail
 
-echo "${MAJOR}Using Open Search and Open Search Dashboards at $OPEN_SEARCH and $OPEN_SEARCH_DASHBOARDS respectively.${RESET}"
-echo "  (set environment variables OPEN_SEARCH and OPEN_SEARCH_DASHBOARDS otherwise)\n"
+if [ -z "$opensearch" ]; then
+    echo "Error: please pass in both the opensearch url and the opensearch dashboard url"
+    exit 1
+fi
+if [ -z "$opensearch_dashboard" ]; then
+    echo "Error: please pass in both the opensearch url and the opensearch dashboard url"
+    exit 1
+fi
+
+echo "${MAJOR}Using Open Search and Open Search Dashboards at $opensearch and $opensearch_dashboard respectively.${RESET}"
 
 echo "${MAJOR}Deleting index sqe_metrics_sample_data${RESET}"
-curl -s -X DELETE http://$OPEN_SEARCH/sqe_metrics_sample_data/ > /dev/null
+curl -s -X DELETE $opensearch/sqe_metrics_sample_data/
 
 echo "${MAJOR}Populating index sqe_metrics_sample_data with sample metric data${RESET}"
-curl -s -H 'Content-Type: application/x-ndjson' -XPOST "$OPEN_SEARCH/sqe_metrics_sample_data/_bulk?pretty=false&filter_path=-items" --data-binary @sample_data.ndjson > /dev/null
+curl -s -H 'Content-Type: application/x-ndjson' -XPOST "$opensearch/sqe_metrics_sample_data/_bulk?pretty=false&filter_path=-items" --data-binary @sample_data.ndjson 
 
 echo "${MAJOR}\nInstalling Quality Evaluation Framework Dashboards${RESET}"
-curl -X POST "http://$OPEN_SEARCH_DASHBOARDS/api/saved_objects/_import?overwrite=true" -H "osd-xsrf: true" --form file=@search_dashboard.ndjson > /dev/null
+curl -X POST "$opensearch_dashboard/api/saved_objects/_import?overwrite=true" -H "osd-xsrf: true" --form file=@search_dashboard.ndjson > /dev/null
 
 echo "${MAJOR}The Quality Evaluation Framework Dashboards were successfully installed${RESET}"


### PR DESCRIPTION
I want to integrate the script into some other processes, so making it take explicit parameters will simplify passing in the urls, especially if they are on https.