### PR TITLE
Fixing field names for zero metrics

### DIFF
--- a/scripts/opensearch-scripts/get-metrics.sh
+++ b/scripts/opensearch-scripts/get-metrics.sh
@@ -1,3 +1,11 @@
 #!/bin/bash -e
 
-curl -s "http://localhost:9200/sqe_metrics_sample_data/_search" | jq
+curl -s "http://localhost:9200/sqe_metrics_sample_data/_search" -H "Content-Type: application/json" -d'{
+  "query": {
+    "range": {
+      "frogs": {
+        "lt": 100 
+      }
+    }
+  }
+}' | jq

--- a/scripts/opensearch-scripts/get-metrics.sh
+++ b/scripts/opensearch-scripts/get-metrics.sh
@@ -1,9 +1,12 @@
 #!/bin/bash -e
 
+#curl -s "http://localhost:9200/sqe_metrics_sample_data/_search" -H "Content-Type: application/json" | jq
+
+
 curl -s "http://localhost:9200/sqe_metrics_sample_data/_search" -H "Content-Type: application/json" -d'{
   "query": {
     "range": {
-      "frogs": {
+      "frogs_percent": {
         "lt": 100 
       }
     }

--- a/scripts/run-query-set.json
+++ b/scripts/run-query-set.json
@@ -1,6 +1,6 @@
 {
-  "query_set_id": "6b1ac777-758d-4f33-9bb6-7e3f15e77637",
-  "judgments_id": "76267535-0591-4e13-9e3d-8de5cb1329a6",
+  "query_set_id": "7b773896-9e1a-43e8-b67d-06debea57c4b",
+  "judgments_id": "14504696-2d7e-4080-b82b-6ef561121683",
   "index": "ecommerce",
   "search_pipeline": "hybrid-search-pipeline",
   "id_field": "asin",

--- a/scripts/run-query-set.json
+++ b/scripts/run-query-set.json
@@ -1,6 +1,6 @@
 {
-  "query_set_id": "7b773896-9e1a-43e8-b67d-06debea57c4b",
-  "judgments_id": "14504696-2d7e-4080-b82b-6ef561121683",
+  "query_set_id": "6c895d94-3146-4d9b-8858-f632e3fb0201",
+  "judgments_id": "40181d0d-fd94-4d91-a4b6-d08230bbaa31",
   "index": "ecommerce",
   "search_pipeline": "hybrid-search-pipeline",
   "id_field": "asin",

--- a/src/main/java/org/opensearch/eval/Constants.java
+++ b/src/main/java/org/opensearch/eval/Constants.java
@@ -18,16 +18,6 @@ public class Constants {
     public static final String UBI_EVENTS_INDEX_NAME = "ubi_events";
 
     /**
-     * The name of the index to store the scheduled jobs to create implicit judgments.
-     */
-    public static final String SCHEDULED_JOBS_INDEX_NAME = "search_quality_eval_scheduled_jobs";
-
-    /**
-     * The name of the index to store the completed jobs to create implicit judgments.
-     */
-    public static final String COMPLETED_JOBS_INDEX_NAME = "search_quality_eval_completed_jobs";
-
-    /**
      * The name of the index that stores the query sets.
      */
     public static final String QUERY_SETS_INDEX_NAME = "search_quality_eval_query_sets";

--- a/src/main/java/org/opensearch/eval/engine/OpenSearchEngine.java
+++ b/src/main/java/org/opensearch/eval/engine/OpenSearchEngine.java
@@ -9,7 +9,6 @@
 package org.opensearch.eval.engine;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,7 +31,6 @@ import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
 import org.opensearch.client.opensearch._types.query_dsl.WrapperQuery;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
-import org.opensearch.client.opensearch.core.ClearScrollRequest;
 import org.opensearch.client.opensearch.core.IndexRequest;
 import org.opensearch.client.opensearch.core.ScrollRequest;
 import org.opensearch.client.opensearch.core.ScrollResponse;
@@ -888,7 +886,7 @@ public class OpenSearchEngine extends SearchEngine {
 
         for(final Judgment judgment : judgments) {
 
-            judgment.setJudgmentsId(judgmentsId);
+            judgment.setJudgmentSetId(judgmentsId);
             judgment.setTimestamp(timestamp);
 
             final IndexRequest<Judgment> indexRequest = new IndexRequest.Builder<Judgment>().index(Constants.JUDGMENTS_INDEX_NAME).id(judgment.getId()).document(judgment).build();

--- a/src/main/java/org/opensearch/eval/engine/OpenSearchEngine.java
+++ b/src/main/java/org/opensearch/eval/engine/OpenSearchEngine.java
@@ -157,7 +157,7 @@ public class OpenSearchEngine extends SearchEngine {
 
         // TODO: Handle the query set not being found.
 
-        return searchResponse.hits().hits().get(0).source();
+        return searchResponse.hits().hits().getFirst().source();
 
     }
 
@@ -167,9 +167,9 @@ public class OpenSearchEngine extends SearchEngine {
         var boolQuery = BoolQuery.of(bq -> bq
                 .must(
                         List.of(
-                            MatchQuery.of(mq -> mq.query(FieldValue.of("judgments_id")).field(judgmentsId)).toQuery(),
-                            MatchQuery.of(mq -> mq.query(FieldValue.of("query")).field(userQuery)).toQuery(),
-                            MatchQuery.of(mq -> mq.query(FieldValue.of("document_id")).field(documentId)).toQuery()
+                            MatchQuery.of(mq -> mq.query(FieldValue.of(judgmentsId)).field("judgment_set_id")).toQuery(),
+                            MatchQuery.of(mq -> mq.query(FieldValue.of(userQuery)).field("query")).toQuery(),
+                            MatchQuery.of(mq -> mq.query(FieldValue.of(documentId)).field("document")).toQuery()
                         )
                 )
         );
@@ -182,14 +182,17 @@ public class OpenSearchEngine extends SearchEngine {
         final SearchResponse<Judgment> searchResponse = client.search(s -> s.index(Constants.JUDGMENTS_INDEX_NAME)
                 .query(query)
                 .from(0)
-                .size(1), Judgment.class);
+                .size(1),
+                Judgment.class);
 
-        System.out.println("Number of judgments: " + searchResponse.hits().hits().size());
+        if(!searchResponse.hits().hits().isEmpty()) {
+            System.out.println("Number of judgments: " + searchResponse.hits().hits().size());
+        }
 
         if(searchResponse.hits().hits().isEmpty()) {
             return Double.NaN;
         } else {
-            return searchResponse.hits().hits().get(0).source().getJudgment();
+            return searchResponse.hits().hits().getFirst().source().getJudgment();
         }
 
     }

--- a/src/main/java/org/opensearch/eval/model/data/AbstractData.java
+++ b/src/main/java/org/opensearch/eval/model/data/AbstractData.java
@@ -10,7 +10,7 @@ package org.opensearch.eval.model.data;
 
 public abstract class AbstractData {
 
-    private final String id;
+    private String id;
 
     public AbstractData(final String id) {
         this.id = id;

--- a/src/main/java/org/opensearch/eval/model/data/Judgment.java
+++ b/src/main/java/org/opensearch/eval/model/data/Judgment.java
@@ -8,12 +8,12 @@
  */
 package org.opensearch.eval.model.data;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.SerializedName;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.eval.utils.MathUtils;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -23,28 +23,29 @@ public class Judgment extends AbstractData {
 
     private static final Logger LOGGER = LogManager.getLogger(Judgment.class.getName());
 
+    @JsonProperty("query_id")
+    @SerializedName("query_id")
     private final String queryId;
-    private final String query;
-    private final String document;
-    private final double judgment;
-    private String judgmentsId;
-    private String timestamp;
 
-    /**
-     * Creates a new judgment.
-     * @param id The judgment ID.
-     * @param queryId The query ID for the judgment.
-     * @param query The query for the judgment.
-     * @param document The document in the judgment.
-     * @param judgment The judgment value.
-     */
-    public Judgment(final String id, final String queryId, final String query, final String document, final double judgment) {
-        super(id);
-        this.queryId = queryId;
-        this.query = query;
-        this.document = document;
-        this.judgment = judgment;
-    }
+    @JsonProperty("query")
+    @SerializedName("query")
+    private final String query;
+
+    @JsonProperty("document")
+    @SerializedName("document")
+    private final String document;
+
+    @JsonProperty("judgment")
+    @SerializedName("judgment")
+    private final double judgment;
+
+    @JsonProperty("judgment_set_id")
+    @SerializedName("judgment_set_id")
+    private String judgmentSetId;
+
+    @JsonProperty("timestamp")
+    @SerializedName("timestamp")
+    private String timestamp;
 
     /**
      * Creates a new judgment.
@@ -63,18 +64,6 @@ public class Judgment extends AbstractData {
 
     public String toJudgmentString() {
         return queryId + ", " + query + ", " + document + ", " + MathUtils.round(judgment);
-    }
-
-    public Map<String, Object> getJudgmentAsMap() {
-
-        final Map<String, Object> judgmentMap = new HashMap<>();
-        judgmentMap.put("query_id", queryId);
-        judgmentMap.put("query", query);
-        judgmentMap.put("document_id", document);
-        judgmentMap.put("judgment", judgment);
-
-        return judgmentMap;
-
     }
 
     @Override
@@ -114,12 +103,12 @@ public class Judgment extends AbstractData {
         return judgment;
     }
 
-    public String getJudgmentsId() {
-        return judgmentsId;
+    public String getJudgmentSetId() {
+        return judgmentSetId;
     }
 
-    public void setJudgmentsId(String judgmentsId) {
-        this.judgmentsId = judgmentsId;
+    public void setJudgmentSetId(String judgmentSetId) {
+        this.judgmentSetId = judgmentSetId;
     }
 
     public String getTimestamp() {

--- a/src/main/java/org/opensearch/eval/model/data/Judgment.java
+++ b/src/main/java/org/opensearch/eval/model/data/Judgment.java
@@ -9,43 +9,37 @@
 package org.opensearch.eval.model.data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.gson.annotations.SerializedName;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.eval.utils.MathUtils;
-
-import java.util.UUID;
 
 /**
  * A judgment of a search result's quality for a given query.
  */
-public class Judgment extends AbstractData {
+public class Judgment {
 
-    private static final Logger LOGGER = LogManager.getLogger(Judgment.class.getName());
+    @JsonProperty("id")
+    private String id;
 
     @JsonProperty("query_id")
-    @SerializedName("query_id")
-    private final String queryId;
+    private String queryId;
 
     @JsonProperty("query")
-    @SerializedName("query")
-    private final String query;
+    private String query;
 
     @JsonProperty("document")
-    @SerializedName("document")
-    private final String document;
+    private String document;
 
     @JsonProperty("judgment")
-    @SerializedName("judgment")
-    private final double judgment;
+    private double judgment;
 
     @JsonProperty("judgment_set_id")
-    @SerializedName("judgment_set_id")
     private String judgmentSetId;
 
     @JsonProperty("timestamp")
-    @SerializedName("timestamp")
     private String timestamp;
+
+    public Judgment() {
+
+    }
 
     /**
      * Creates a new judgment.
@@ -55,7 +49,6 @@ public class Judgment extends AbstractData {
      * @param judgment The judgment value.
      */
     public Judgment(final String queryId, final String query, final String document, final double judgment) {
-        super(UUID.randomUUID().toString());
         this.queryId = queryId;
         this.query = query;
         this.document = document;
@@ -117,6 +110,14 @@ public class Judgment extends AbstractData {
 
     public void setTimestamp(String timestamp) {
         this.timestamp = timestamp;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
     }
 
 }

--- a/src/main/java/org/opensearch/eval/model/data/QueryResultMetric.java
+++ b/src/main/java/org/opensearch/eval/model/data/QueryResultMetric.java
@@ -1,17 +1,36 @@
 package org.opensearch.eval.model.data;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.UUID;
 
 public class QueryResultMetric extends AbstractData {
 
+    @JsonProperty("datetime")
     private String datetime;
+
+    @JsonProperty("search_config")
     private String searchConfig;
+
+    @JsonProperty("query_set_id")
     private String querySetId;
+
+    @JsonProperty("query")
     private String query;
+
+    @JsonProperty("metric")
     private String metric;
+
+    @JsonProperty("value")
     private double value;
+
+    @JsonProperty("application")
     private String application;
+
+    @JsonProperty("evaluation_id")
     private String evaluationId;
+
+    @JsonProperty("frogs_percent")
     private double frogsPercent;
 
     public QueryResultMetric(String id) {

--- a/src/main/java/org/opensearch/eval/runners/AbstractQuerySetRunner.java
+++ b/src/main/java/org/opensearch/eval/runners/AbstractQuerySetRunner.java
@@ -53,7 +53,7 @@ public abstract class AbstractQuerySetRunner {
      */
     protected RelevanceScores getRelevanceScores(final String judgmentsId, final String query, final List<String> orderedDocumentIds, final int k) throws Exception {
 
-        // Ordered list of scores.
+        // An ordered list of scores.
         final List<Double> scores = new ArrayList<>();
 
         // Count the number of documents without judgments.


### PR DESCRIPTION
Gives metrics now:

```
      {
        "_index": "sqe_metrics_sample_data",
        "_id": "2da1c9ca-7fa4-465e-8b2e-f3dd17e0972b",
        "_score": 1,
        "_source": {
          "id": "2da1c9ca-7fa4-465e-8b2e-f3dd17e0972b",
          "datetime": "2025-01-28T17:00:23.067Z",
          "search_config": "research_1",
          "query_set_id": "6c895d94-3146-4d9b-8858-f632e3fb0201",
          "query": "mini fridge",
          "metric": "dcg_at_10",
          "value": 46.031503752819155,
          "application": "sample_data",
          "evaluation_id": "31f84085-2d36-4a58-a596-ed072e17075e",
          "frogs_percent": 90
        }
      },
```